### PR TITLE
Misc bug patches

### DIFF
--- a/Items/BasePkballProjectile.cs
+++ b/Items/BasePkballProjectile.cs
@@ -245,32 +245,16 @@ namespace TerramonMod.Items
 
         public void PokemonCatchSuccess()
         {
-            if (Main.player[Projectile.owner].whoAmI == Main.myPlayer)
-            {
-                //Main.player[Projectile.owner].GetModPlayer<tmonPlayer>().AddPokemon(capture.info);
-                //Item pokemon = new Item(ModContent.ItemType<PokeballItem>());
-                //var modItem = (BasePkballItem)pokemon.ModItem;
-                /*var givePkball = ModContent.GetModItem(pokeballCapture) as BasePkballItem;
-                givePkball.data = new PkmnData { pkmn = capture.Type, level = capture.level };
-                givePkball.SetUnsellable();
-                givePkball.UpdateName();
-                //givePkball.Item.position = Main.player[Projectile.owner].position;
-                Item i = new();
-                givePkball.Clone(i);
-                i.position = Main.player[Projectile.owner].position;*/
-
-                var givePkball = Main.player[Projectile.owner].QuickSpawnItemDirect(this.Entity.GetSource_DropAsItem(), pokeballCapture).ModItem as BasePkballItem;
-                givePkball.data = new PkmnData { pkmn = capture.GetType().Name, level = capture.level, isShiny = capture.isShiny };
-                givePkball.SetUnsellable();
-                givePkball.UpdateName();
-                //Item.NewItem(this.Entity.GetSource_DropAsItem(), Main.player[Projectile.owner].position, pokeballCapture);
-
-                //item.hold.Nickname = "Keffreye";
+            var newItem = Item.NewItem(this.Entity.GetSource_DropAsItem(), Main.player[Projectile.owner].position, pokeballCapture);
+            var newPkball = Main.item[newItem].ModItem as BasePkballItem;
+            newPkball.SetContents(new PkmnData { pkmn = capture.GetType().Name, level = capture.level, isShiny = capture.isShiny });
+            if (Main.netMode == NetmodeID.MultiplayerClient)
+                NetMessage.SendData(MessageID.SyncItem, -1, -1, null, newItem, 1f);
+            //item.hold.Nickname = "Keffreye";
 
 
-                SoundEngine.PlaySound(new SoundStyle("TerramonMod/Sounds/pkball_catch_pla"));
-                Main.NewText($"Congratulations! You caught a level {givePkball.data.level} {capture.info.Name}", Color.Orange);
-            }
+            SoundEngine.PlaySound(new SoundStyle("TerramonMod/Sounds/pkball_catch_pla"));
+            Main.NewText($"Congratulations! You caught a level {capture.level} {capture.info.Name}", Color.Orange);
             Projectile.Kill();
         }
 

--- a/Items/Consumable/RareCandy.cs
+++ b/Items/Consumable/RareCandy.cs
@@ -31,10 +31,23 @@ namespace TerramonMod.Items.Consumable
         }
         public override bool CanUseItem(Player player)
         {
-            if (player.GetModPlayer<TerramonPlayer>().pokeInUse != null)
-                return true;
-            Main.NewText("You need to summon your Pokemon to use this item!", Color.Red);
-            return false;
+            bool hasPokemon = player.GetModPlayer<TerramonPlayer>().pokeInUse != null;
+            if (!hasPokemon)
+            {
+                Main.NewText("You need to summon your Pokemon to use this item!", Color.Red);
+                return false;
+            }
+            else
+            {
+                bool canLevelUp = player.GetModPlayer<TerramonPlayer>().pokeInUse.data.CanLevelUp();
+                if (!canLevelUp)
+                {
+                    Main.NewText("Your Pokemon's level can't get any higher!", Color.Red);
+                    return false;
+                }
+                else
+                    return true;
+            }
         }
 
         public override bool? UseItem(Player player) //Manage what happens when the player uses the item

--- a/Pokemon/BasePkmn.cs
+++ b/Pokemon/BasePkmn.cs
@@ -20,8 +20,8 @@ namespace TerramonMod.Pokemon
     {
 		public virtual PkmnInfo info => null;
 		public virtual int wildLevel => 0;
-		public virtual float commodity => 0.05f;
-		public virtual bool doesFly => true;
+		public virtual float commodity => 1f;
+		public virtual bool doesFly => false;
 
 		public bool isShiny = false;
 		public bool catchable = true;
@@ -81,7 +81,7 @@ namespace TerramonMod.Pokemon
 			NPC.HitSound = null;
 			NPC.DeathSound = null;
 			NPC.netAlways = true;
-			NPC.noGravity = true;
+			//NPC.noGravity = true;
 			//NPC.wet = true;
 			//NPC.scale = 2;
 			//NPC.dontTakeDamage = true;
@@ -110,7 +110,7 @@ namespace TerramonMod.Pokemon
 					// TODO: add in spawning for more types
             }
 
-            return spawnChance;
+            return spawnChance * 0.05f;
 		}
 
 		public override void FindFrame(int frameHeight)

--- a/Pokemon/PkmnData.cs
+++ b/Pokemon/PkmnData.cs
@@ -38,9 +38,17 @@ namespace TerramonMod.Pokemon
             return 0;
         }
 
+        public bool CanLevelUp()
+        {
+            if (level >= 100)
+                return false;
+            else
+                return true;
+        }
+
         public bool LevelUp(int howMany = 1)
         {
-            if (level == 100)
+            if (!CanLevelUp())
                 return false;
 
             level += howMany;


### PR DESCRIPTION
- Pokeball items given after a catch now have contents in multiplayer
- Pokeball item now checks if it has been thrown into world and despawns its player's Pokemon projectile if true
- New bool in PkmnData indicating whether the Pokemon can increase in level
- Rare Candies can't be used if the Pokemon is at max level
- Disabled flying AI as this still isn't working properly
- Set default Pokemon spawn commodity to 1 and decrease this later in SpawnChance() for better readability
- New method SetContents() in BasePkballItem to set contents so invalid data can be handled + item can be updated automatically
- Remove SetUnsellable() as this was only used when adding contents to the Pokeball (done in SetContents()