### PR TITLE
Add Starter Selection UI

### DIFF
--- a/TerramonMod.cs
+++ b/TerramonMod.cs
@@ -20,6 +20,7 @@ namespace TerramonMod
 	{
 		public static bool fastAnimations = false;
 		public static bool fastEvolution = true;
+		public static bool randomStarters = false;
 
 		public enum PkmnType
 		{

--- a/TerramonSystem.cs
+++ b/TerramonSystem.cs
@@ -13,36 +13,65 @@ namespace TerramonMod
 {
     class TerramonSystem : ModSystem
     {
-		/*internal TestCanvas testCanvas;
-		private UserInterface _testUI;
-		public override void Load()
-		{
-			testCanvas = new TestCanvas();
-			testCanvas.Activate();
-			_testUI = new UserInterface();
-			_testUI.SetState(testCanvas);
-		}
-		public override void UpdateUI(GameTime gameTime)
-		{
-			_testUI?.Update(gameTime);
-		}
+		internal TestCanvas terramonCanvas;
+		internal UserInterface terramonUI;
 
-		public override void ModifyInterfaceLayers(List<GameInterfaceLayer> layers)
-		{
-			int mouseTextIndex = layers.FindIndex(layer => layer.Name.Equals("Vanilla: Mouse Text"));
-			if (mouseTextIndex != -1)
-			{
-				layers.Insert(mouseTextIndex, new LegacyGameInterfaceLayer(
-					"TerramonMod: A Description",
-					delegate
-					{
-						_testUI.Draw(Main.spriteBatch, new GameTime());
-						return true;
-					},
-					InterfaceScaleType.UI)
-				);
-			}
-		}*/
-	}
+        private GameTime _lastUpdateUiGameTime;
+
+        public override void Load()
+        {
+            if (!Main.dedServ)
+            {
+                terramonUI = new UserInterface();
+
+                terramonCanvas = new TestCanvas();
+                terramonCanvas.Activate(); // Activate calls Initialize() on the UIState if not initialized and calls OnActivate, then calls Activate on every child element.
+            }
+        }
+
+        public override void Unload()
+        {
+            terramonCanvas = null;
+        }
+
+
+        public override void UpdateUI(GameTime gameTime)
+        {
+            //update canvas and all of its elements
+            _lastUpdateUiGameTime = gameTime;
+            if (terramonUI?.CurrentState != null)
+            {
+                terramonUI.Update(gameTime);
+            }
+        }
+        public override void ModifyInterfaceLayers(List<GameInterfaceLayer> layers)
+        {
+            //add custom layer to ui and make it draw itself
+            int mouseTextIndex = layers.FindIndex(layer => layer.Name.Equals("Vanilla: Mouse Text"));
+            if (mouseTextIndex != -1)
+            {
+                layers.Insert(mouseTextIndex, new LegacyGameInterfaceLayer(
+                    "TerramonMod: Terramon UI",
+                    delegate
+                    {
+                        if (_lastUpdateUiGameTime != null && terramonUI?.CurrentState != null)
+                        {
+                            terramonUI.Draw(Main.spriteBatch, _lastUpdateUiGameTime);
+                        }
+                        return true;
+                    },
+                    InterfaceScaleType.UI));
+            }
+        }
+        internal void ShowStarterUI()
+        {
+            terramonUI?.SetState(terramonCanvas);
+        }
+
+        internal void HideStarterUI()
+        {
+            terramonUI?.SetState(null);
+        }
+    }
 
 }

--- a/UI/StarterPkmn.cs
+++ b/UI/StarterPkmn.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.ModLoader;
+using Terraria.UI;
+using ReLogic.Content;
+using TerramonMod.Items;
+using TerramonMod.Items.Pokeballs;
+using TerramonMod.Pokemon;
+using Terraria.ID;
+using Terraria.GameContent.UI.Elements;
+
+namespace TerramonMod.UI
+{
+    class StarterPkmn : UIImageButton
+    {
+        string pokemon;
+        string descriptor;
+        UIText text;
+        Asset<Texture2D> texture;
+
+        public StarterPkmn(string pokemon, string descriptor, UIText text) : base(ModContent.Request<Texture2D>($"TerramonMod/Minisprites/SidebarSprites/{pokemon}"))
+        {
+            this.pokemon = pokemon;
+            this.descriptor = descriptor;
+            this.text = text;
+            this.texture = ModContent.Request<Texture2D>($"TerramonMod/Minisprites/mini{pokemon}");
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            base.Update(gameTime);
+
+            if (IsMouseHovering)
+            {
+                if (descriptor == null)
+                    text.SetText(pokemon);
+                else
+                    text.SetText($"{pokemon}, the {descriptor} Pokemon");
+            }
+
+            Main.LocalPlayer.delayUseItem = IsMouseHovering;
+        }
+
+        public override void LeftClick(UIMouseEvent evt)
+        {
+            base.LeftClick(evt);
+
+            var newItem = Main.LocalPlayer.QuickSpawnItem(Main.LocalPlayer.GetSource_GiftOrReward(), ModContent.ItemType<PokeBallItem>());
+            var newPkball = Main.item[newItem].ModItem as BasePkballItem;
+            newPkball.SetContents(new PkmnData { pkmn = pokemon + "NPC", level = 5 });
+
+            if (Main.netMode == NetmodeID.MultiplayerClient)
+                NetMessage.SendData(MessageID.SyncItem, -1, -1, null, newItem, 1f);
+
+            Main.LocalPlayer.GetModPlayer<TerramonPlayer>().hasChosenStarter = true;
+            ModContent.GetInstance<TerramonSystem>().HideStarterUI();
+        }
+        /*public override void Draw(SpriteBatch spriteBatch)
+        {
+            var position = new Vector2(HAlign, VAlign);
+            spriteBatch.Draw(texture.Value, position, null, Color.White, 0, Vector2.One / 2, 2.5f, SpriteEffects.None, 0);
+        }*/
+    }
+}

--- a/UI/TestCanvas.cs
+++ b/UI/TestCanvas.cs
@@ -1,5 +1,9 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Reflection;
+using TerramonMod.Pokemon;
+using Terraria;
 using Terraria.GameContent.UI.Elements;
 using Terraria.ModLoader;
 using Terraria.UI;
@@ -8,13 +12,88 @@ namespace TerramonMod.UI
 {
     class TestCanvas : UIState
     {
-        public UIHoverImageButton playButton;
+        public string GetRandomPoke()
+        {
+            string targetNamespace = "TerramonMod.Pokemon.Gen1";
+            Assembly assembly = Assembly.GetExecutingAssembly(); // or any other assembly where your classes reside
+
+            Type[] types = assembly.GetTypes();
+            string poke = null;
+
+            do {
+                var random = types[Main.rand.Next(0, types.Length - 1)];
+                if (random.Namespace == targetNamespace && random.BaseType == typeof(BasePkmn))
+                {
+                    var randomPoke = (BasePkmn)Activator.CreateInstance(random);
+                    if (randomPoke.wildLevel == 0)
+                    poke = random.Name;
+                }
+            } 
+            while (poke == null);
+
+            poke = poke.Replace("NPC", null);
+            poke = poke.Replace("Pet", null);
+
+            return poke;
+        }
 
         public override void OnInitialize()
         {
-            playButton = new SidebarPkmn(new Vector2(200, 500));
+            //(test) add panel to ui
+            UIPanel panel = new UIPanel();
+            panel.Width.Set(0, 0.3f);
+            panel.Height.Set(0, 0.3f);
+            //panel.Left.Set(0, 0.5f - (panel.Width.Percent / 2));
+            //panel.Top.Set(0, 0.45f - (panel.Width.Percent / 2));
+            panel.HAlign = 0.5f;
+            panel.VAlign = 0.45f;
+            Append(panel);
 
-            Append(playButton);
+            UIText text = new UIText("Choose your Starter Pokemon", 1.5f);
+            text.HAlign = 0.5f;
+            text.Top.Set(0, 0.05f);
+            panel.Append(text);
+
+            UIText nameText = new UIText("", 1.25f);
+            nameText.HAlign = 0.5f;
+            nameText.Top.Set(0, 0.85f);
+            panel.Append(nameText);
+
+            StarterPkmn starter1 = null;
+            StarterPkmn starter2 = null;
+            StarterPkmn starter3 = null;
+
+            if (TerramonMod.randomStarters)
+            {
+                starter1 = new StarterPkmn(GetRandomPoke(), null, nameText);
+                starter2 = new StarterPkmn(GetRandomPoke(), null, nameText);
+                starter3 = new StarterPkmn(GetRandomPoke(), null, nameText);
+            }
+            else
+            {
+                starter1 = new StarterPkmn("Charmander", "Lizard", nameText);
+                starter2 = new StarterPkmn("Squirtle", "Tiny Turtle", nameText);
+                starter3 = new StarterPkmn("Bulbasaur", "Seed", nameText);
+            }
+
+            starter1.Width.Set(0, 0.2f);
+            starter1.Height.Set(0, 0.2f);
+            starter1.HAlign = 0.15f;
+            starter1.VAlign = 0.5f;
+            panel.Append(starter1);
+
+            starter2.Width.Set(0, 0.2f);
+            starter2.Height.Set(0, 0.2f);
+            starter2.HAlign = 0.5f;
+            starter2.VAlign = 0.5f;
+            panel.Append(starter2);
+
+            starter3.Width.Set(0, 0.2f);
+            starter3.Height.Set(0, 0.2f);
+            starter3.HAlign = 0.85f;
+            starter3.VAlign = 0.5f;
+            panel.Append(starter3);
+
         }
     }
 }

--- a/UI/UIHoverImageButton.cs
+++ b/UI/UIHoverImageButton.cs
@@ -1,55 +1,31 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
 using Terraria;
 using Terraria.GameContent.UI.Elements;
-using Terraria.ModLoader;
-using Terraria.UI;
 
 namespace TerramonMod.UI
 {
-    class UIHoverImageButton : UIImageButton
-    {
-        internal string HoverText;
-        internal Vector2 drawPosition;
-        public UIHoverImageButton(ReLogic.Content.Asset<Texture2D> texture, string hoverText) : base(texture)
-        {
-            HoverText = hoverText;
-        }
+	// This UIHoverImageButton class inherits from UIImageButton. 
+	// Inheriting is a great tool for UI design. 
+	// By inheriting, we get the Image drawing, MouseOver sound, and fading for free from UIImageButton
+	// We've added some code to allow the Button to show a text tooltip while hovered. 
+	internal class UIHoverImageButton : UIImageButton
+	{
+		internal string HoverText;
 
-        public override void Update(GameTime gameTime)
-        {
-            base.Update(gameTime);
+		public UIHoverImageButton(Asset<Texture2D> texture, string hoverText) : base(texture)
+		{
+			HoverText = hoverText;
+		}
 
-            if (isHover)
-                Main.LocalPlayer.mouseInterface = true;
-        }
+		protected override void DrawSelf(SpriteBatch spriteBatch)
+		{
+			base.DrawSelf(spriteBatch);
 
-        bool isHover = false;
-        //bool origUseState = false;
-
-        public override void MouseOver(UIMouseEvent evt)
-        {
-            isHover = true;
-            //origUseState = Main.LocalPlayer.delayUseItem;
-        }
-
-        public override void MouseOut(UIMouseEvent evt)
-        {
-            isHover = false;
-            //Main.LocalPlayer.delayUseItem = origUseState;
-        }
-
-        protected override void DrawSelf(SpriteBatch spriteBatch)
-        {
-            base.DrawSelf(spriteBatch);
-
-            if (IsMouseHovering)
-            {
-                Main.hoverItemName = HoverText;
-            }
-        }
-    }
+			if (IsMouseHovering)
+			{
+				Main.hoverItemName = HoverText;
+			}
+		}
+	}
 }


### PR DESCRIPTION
- Add Starter Selection UI
- Move Player starter Pokeballs to only trigger after starter is selected rather than on every respawn
- Add bool to check if starter has been selected + check if pokeballs have been given
- Add random starters feature (currently unused)