### PR TITLE
Rare Candy + Stones loot

### DIFF
--- a/ChestGen.cs
+++ b/ChestGen.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.ID;
+
+namespace GenUtils
+{
+    class ChestGen
+    {
+        public static void AddChestLoot(int itemID, int chestID = -1, int minimumStack = 1, int maximumStack = 1, int chance = 10000, bool excludeDuplicates = false) =>
+            AddChestLoot(itemID, chestID == -1 ? null : new List<int>() { chestID }, minimumStack, maximumStack, chance, excludeDuplicates);
+
+        public static void AddChestLoot(int itemID, List<int> chestIDs, int minimumStack = 1, int maximumStack = 1, int chance = 10000, bool excludeDuplicates = false)
+        {
+            if (maximumStack < minimumStack)
+                maximumStack = minimumStack;
+
+            for (int chestIndex = 0; chestIndex < Main.maxChests; chestIndex++)
+            {
+                //if the drop chance for this chest is unsuccessful, skip this chest
+                if (WorldGen.genRand.Next(0, 10000) <= chance)
+                    continue;
+
+                Chest chest = Main.chest[chestIndex];
+                //check if the chest actually exists
+                if (chest != null && Main.tile[chest.x, chest.y].TileType == TileID.Containers)
+                {
+                    //make sure the chest is the right type that we are looking for
+                    if (chestIDs == null || chestIDs.Contains(Main.tile[chest.x, chest.y].TileFrameX / 36))
+                    {
+                        //check all slots
+                        for (int inventoryIndex = 0; inventoryIndex < Chest.maxItems; inventoryIndex++)
+                        {
+                            //if slot contains our item and duplicates are disabled, skip this chest
+                            if (chest.item[inventoryIndex].type == itemID && excludeDuplicates)
+                                break;
+                            //if slot is empty or already contains our item
+                            else if ((chest.item[inventoryIndex].IsAir || chest.item[inventoryIndex].type == itemID))
+                            {
+                                var amount = WorldGen.genRand.Next(minimumStack, maximumStack + 1);
+
+                                //break if the amount is 0 (shouldn't try to add an item)
+                                if (amount == 0)
+                                    break;
+
+                                //only create new item if none exists
+                                if (chest.item[inventoryIndex].IsAir)
+                                {
+                                    chest.item[inventoryIndex].SetDefaults(itemID);
+                                    chest.item[inventoryIndex].stack = 0;
+                                }
+
+                                chest.item[inventoryIndex].stack += amount;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public static void RemoveChestLoot(int itemID, int chestID = -1, int minimumAmount = 1, int maximumAmount = 1, int chance = 10000) =>
+            RemoveChestLoot(itemID, chestID == -1 ? null : new List<int>() { chestID }, minimumAmount, maximumAmount, chance);
+
+        public static void RemoveChestLoot(int itemID, List<int> chestIDs, int minimumAmount = 1, int maximumAmount = 1, int chance = 10000)
+        {
+            if (maximumAmount < minimumAmount)
+                maximumAmount = minimumAmount;
+
+            for (int chestIndex = 0; chestIndex < Main.maxChests; chestIndex++)
+            {
+                //if the chance for this chest is unsuccessful, skip this chest
+                if (WorldGen.genRand.Next(0, 10000) <= chance)
+                    continue;
+
+                Chest chest = Main.chest[chestIndex];
+                //check if the chest actually exists
+                if (chest != null && Main.tile[chest.x, chest.y].TileType == TileID.Containers)
+                {
+                    //make sure the chest is the right type that we are looking for
+                    if (chestIDs == null || chestIDs.Contains(Main.tile[chest.x, chest.y].TileFrameX / 36))
+                    {
+                        //check all slots
+                        for (int inventoryIndex = 0; inventoryIndex < Chest.maxItems; inventoryIndex++)
+                        {
+                            //if slot contains our item
+                            if (chest.item[inventoryIndex].type == itemID)
+                            {
+                                var amount = WorldGen.genRand.Next(minimumAmount, maximumAmount + 1);
+
+                                //break if the amount is 0 (shouldn't try to remove an item)
+                                if (amount == 0)
+                                    break;
+
+                                //remove item if stack will be less than 1
+                                if (chest.item[inventoryIndex].stack - amount <= 0)
+                                    chest.item[inventoryIndex].SetDefaults(0);
+                                else
+                                    chest.item[inventoryIndex].stack -= amount;
+
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public class ChestID
+    {
+        public const short Default = 0;
+        public const short Gold = 1;
+        public const short Gold_Locked = 2;
+        public const short Shadow = 3;
+        public const short Shadow_Locked = 4;
+        public const short Barrel = 5;
+        public const short TrashCan = 6;
+        public const short Ebonwood = 7;
+        public const short RichMahogany = 8;
+        public const short Pearlwood = 9;
+        public const short Ivy = 10;
+        public const short Frozen = 11;
+        public const short LivingWood = 12;
+        public const short Skyware = 13;
+        public const short Shadewood = 14;
+        public const short WebCovered = 15;
+        public const short Lihzahrd = 16;
+        public const short Water = 17;
+        public const short Jungle = 18;
+        public const short Corruption = 19;
+        public const short Crimson = 20;
+        public const short Hallowed = 21;
+        public const short Ice = 22;
+        public const short Jungle_Locked = 23;
+        public const short Corruption_Locked = 24;
+        public const short Crimson_Locked = 25;
+        public const short Hallowed_Locked = 26;
+        public const short Ice_Locked = 27;
+        public const short Dynasty = 28;
+        public const short Honey = 29;
+        public const short Steampunk = 30;
+        public const short PalmWood = 31;
+        public const short Mushroom = 32;
+        public const short BorealWood = 33;
+        public const short Slime = 34;
+        public const short GreenDungeon = 35;
+        public const short GreenDungeon_Locked = 36;
+        public const short PinkDungeon = 37;
+        public const short PinkDungeon_Locked = 38;
+        public const short BlueDungeon = 39;
+        public const short BlueDungeon_Locked = 40;
+        public const short Bone = 41;
+        public const short Cactus = 42;
+        public const short Flesh = 43;
+        public const short Obsidian = 44;
+        public const short Pumpkin = 45;
+        public const short Spooky = 46;
+        public const short Glass = 47;
+        public const short Martian = 48;
+        public const short Meteorite = 49;
+        public const short Granite = 50;
+        public const short Marble = 51;
+        public const short Crystal = 52;
+        public const short GoldPirate = 53;
+        public static List<int> Dungeon = new List<int> { GreenDungeon, GreenDungeon_Locked, PinkDungeon, PinkDungeon_Locked, BlueDungeon, BlueDungeon_Locked, Gold_Locked };
+        public static List<int> DungeonLocked = new List<int> { GreenDungeon_Locked, PinkDungeon_Locked, BlueDungeon_Locked, Gold_Locked };
+        public static List<int> DungeonUnlocked = new List<int> { GreenDungeon, PinkDungeon, BlueDungeon };
+        public static List<int> DungeonSpecial = new List<int> { Corruption_Locked, Crimson_Locked, Ice_Locked, Jungle_Locked, Hallowed_Locked };
+        public static List<int> Locked = new List<int> { BlueDungeon_Locked, Corruption_Locked, Crimson_Locked, Gold_Locked, GreenDungeon_Locked, Hallowed_Locked, Ice_Locked, Jungle_Locked, PinkDungeon_Locked, Shadow_Locked };
+        public static List<int> LivingTrees = new List<int> { LivingWood, Ivy };
+    }
+}

--- a/Items/BasePkballItem.cs
+++ b/Items/BasePkballItem.cs
@@ -80,7 +80,7 @@ namespace TerramonMod.Items
 
 			if (data != null)
 			{
-				string suffix = data.isShiny ? "_Shiny" : "";
+				string suffix = data.isShiny || data.isShimmer ? "_Shiny" : "";
 				string texture = ModContent.GetModProjectile(data.GetInfo().petType).Texture.Replace($"Pokemon/Gen{data.GetInfo().gen}/", "Minisprites/mini");
 
 				Texture2D pokemonSprite = ModContent.Request<Texture2D>($"{texture}{suffix}").Value;
@@ -126,6 +126,16 @@ namespace TerramonMod.Items
 			var other = (BasePkballItem)item2.ModItem;
 			if (data == null && other.data == null) //Only stack if both items are empty
 				return true;
+			/*if (data != null && other.data != null)
+			{
+				//swap data of other ball and this ball
+				var tempData = data;
+				data = other.data;
+				other.data = tempData;
+				other.UpdateName();
+				UpdateName();
+				return false;
+			}*/ //removed due to swapping balls whenever a new one is picked up
 			return false;
         }
 		public override bool CanStackInWorld(Item item2) => CanStack(item2);

--- a/Items/ChestLoot.cs
+++ b/Items/ChestLoot.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+using System.Collections.Generic;
+using Terraria.GameContent.ItemDropRules;
+using TerramonMod.Items.Consumable;
+using Terraria.WorldBuilding;
+using TerramonMod.Items.Pokeballs;
+using Terraria.IO;
+using GenUtils;
+
+namespace TerramonMod.Items
+{
+    public class TerramonItemPass : GenPass
+    {
+        public TerramonItemPass(string name, float loadWeight) : base(name, loadWeight)
+        {
+        }
+
+        protected override void ApplyPass(GenerationProgress progress, GameConfiguration configuration)
+        {
+            progress.Message = "Scattering candies";
+            
+            ChestGen.AddChestLoot(ModContent.ItemType<RareCandy>(), ChestID.Gold, minimumStack: 1, maximumStack: 3, chance: 7500);
+            ChestGen.AddChestLoot(ModContent.ItemType<RareCandy>(), minimumStack: 1, maximumStack: 2, chance: 3500, excludeDuplicates: true);
+            ChestGen.AddChestLoot(ModContent.ItemType<WaterStone>(), ChestID.Water, chance: 8500);
+            ChestGen.AddChestLoot(ModContent.ItemType<ThunderStone>(), ChestID.Dungeon, chance: 500);
+            ChestGen.AddChestLoot(ModContent.ItemType<FireStone>(), ChestID.Shadow_Locked, chance: 1000);
+            ChestGen.AddChestLoot(ModContent.ItemType<LeafStone>(), ChestID.LivingTrees, chance: 4000);
+            ChestGen.AddChestLoot(ModContent.ItemType<MoonStone>(), ChestID.Gold, chance: 750);
+
+        }
+    }
+
+    class ChestLoot : ModSystem
+    {
+        public override void ModifyWorldGenTasks(List<GenPass> tasks, ref double totalWeight)
+        {
+            int potsIndex = tasks.FindIndex(genpass => genpass.Name.Equals("Pots"));
+            if (potsIndex != -1)
+                tasks.Insert(potsIndex + 1, new TerramonItemPass("Terramon Items", 237.4298f));
+        }
+    }
+}

--- a/Items/Consumable/BaseEvolveItem.cs
+++ b/Items/Consumable/BaseEvolveItem.cs
@@ -21,9 +21,9 @@ namespace TerramonMod.Items.Consumable
         }
         public override void SetDefaults()
         {
-            Item.useStyle = 5;// ItemUseStyleID.HoldUp;
+            Item.useStyle = ItemUseStyleID.Shoot;// ItemUseStyleID.HoldUp;
             Item.maxStack = 999;
-            Item.value = 3000;
+            Item.value = 100000;
             Item.consumable = true;
             Item.UseSound = null;
             Item.useTime = 20;

--- a/Items/Consumable/FireStone.cs
+++ b/Items/Consumable/FireStone.cs
@@ -5,8 +5,14 @@ using Terraria;
 
 namespace TerramonMod.Items.Consumable
 {
-    class FireStone : BaseEvolveItem
-    {
-        public override string ItemKey => "FireStone";
-    }
+	class FireStone : BaseEvolveItem
+	{
+		public override string ItemKey => "FireStone";
+		public override void AddRecipes()
+		{
+			CreateRecipe()
+			.AddCustomShimmerResult(ModContent.ItemType<WaterStone>())
+			.Register();
+		}
+	}
 }

--- a/Items/Consumable/LinkCable.cs
+++ b/Items/Consumable/LinkCable.cs
@@ -8,5 +8,10 @@ namespace TerramonMod.Items.Consumable
     class LinkCable : BaseEvolveItem
     {
         public override string ItemKey => "LinkCable";
+
+        public override void SetStaticDefaults()
+        {
+            Item.value = 3000;
+        }
     }
 }

--- a/Items/Consumable/RareCandy.cs
+++ b/Items/Consumable/RareCandy.cs
@@ -22,7 +22,7 @@ namespace TerramonMod.Items.Consumable
         }
         public override void SetDefaults()
         {
-            Item.useStyle = 5;// ItemUseStyleID.HoldUp;
+            Item.useStyle = ItemUseStyleID.Shoot;// ItemUseStyleID.HoldUp;
             Item.maxStack = 999;
             Item.value = 3000;
             Item.consumable = true;
@@ -79,5 +79,11 @@ namespace TerramonMod.Items.Consumable
             return new Vector2(-2, 4);
         }
 
+        public override void AddRecipes()
+        {
+            CreateRecipe()
+            .AddCustomShimmerResult(ItemID.CandyCane, 3)
+            .Register();
+        }
     }
 }

--- a/Items/Consumable/ThunderStone.cs
+++ b/Items/Consumable/ThunderStone.cs
@@ -8,5 +8,11 @@ namespace TerramonMod.Items.Consumable
     class ThunderStone : BaseEvolveItem
     {
         public override string ItemKey => "ThunderStone";
+        public override void AddRecipes()
+        {
+            CreateRecipe()
+            .AddCustomShimmerResult(ModContent.ItemType<FireStone>())
+            .Register();
+        }
     }
 }

--- a/Items/Consumable/WaterStone.cs
+++ b/Items/Consumable/WaterStone.cs
@@ -8,5 +8,11 @@ namespace TerramonMod.Items.Consumable
     class WaterStone : BaseEvolveItem
     {
         public override string ItemKey => "WaterStone";
+        public override void AddRecipes()
+        {
+            CreateRecipe()
+            .AddCustomShimmerResult(ModContent.ItemType<ThunderStone>())
+            .Register();
+        }
     }
 }

--- a/Items/NPCLoot.cs
+++ b/Items/NPCLoot.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+using System.Collections.Generic;
+using Terraria.GameContent.ItemDropRules;
+using TerramonMod.Items.Consumable;
+
+namespace TerramonMod.Items
+{
+    class NPCLoot : GlobalNPC
+    {
+        public override void ModifyNPCLoot(NPC npc, Terraria.ModLoader.NPCLoot npcLoot)
+        {
+            if (!npc.boss)
+                npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<RareCandy>(), 32));
+            else
+            {
+                int amount = 0;
+                switch (npc.type)
+                {
+                    case NPCID.KingSlime:
+                    case NPCID.Deerclops:
+                    case NPCID.QueenBee:
+                    case NPCID.Spazmatism:
+                    case NPCID.Retinazer:
+                        amount = 3;
+                        break;
+
+                    case NPCID.EyeofCthulhu:
+                    case NPCID.SkeletronHead:
+                    case NPCID.BrainofCthulhu:
+                        amount = 5;
+                        break;
+
+                    case NPCID.WallofFlesh:
+                    case NPCID.QueenSlimeBoss:
+                    case NPCID.SkeletronPrime:
+                        amount = 7;
+                        break;
+
+                    case NPCID.Plantera:
+                    case NPCID.Golem:
+                    case NPCID.DukeFishron:
+                        amount = 9;
+                        break;
+
+                    case NPCID.HallowBoss:
+                    case NPCID.CultistBoss:
+                    case NPCID.MoonLordHead:
+                        amount = 11;
+                        break;
+                }
+
+                if (Main.expertMode)
+                    amount = (int)(amount * 1.5);
+                npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<RareCandy>(), minimumDropped: amount, maximumDropped: amount));
+            }
+        }
+
+        public override void ModifyActiveShop(NPC npc, string shopName, Item[] items)
+        {
+            if (npc.type == NPCID.Mechanic)
+                foreach (var item in items)
+                    if (item.IsAir)
+                    {
+                        item.SetDefaults(ModContent.ItemType<LinkCable>());
+                        break;
+                    }
+
+
+        }
+    }
+}

--- a/Localization/en-US_Mods.TerramonMod.hjson
+++ b/Localization/en-US_Mods.TerramonMod.hjson
@@ -92,6 +92,11 @@ Items: {
 		DisplayName: Linking Cord
 		Tooltip: A cable that makes you feel a strange sense of connection. It’s loved by certain Pokemon.
 	}
+
+	ShimmerBallItem: {
+		DisplayName: Shimmer Ball Item
+		Tooltip: ""
+	}
 }
 
 NPCs: {
@@ -422,6 +427,7 @@ Projectiles: {
 	ZubatPet.DisplayName: Zubat
 	NidoranFPet.DisplayName: Nidoran F
 	NidoranMPet.DisplayName: Nidoran M
+	ShimmerBallProjectile.DisplayName: Shimmer Ball Projectile
 }
 
 Configs: {

--- a/Pokemon/BasePkmn.cs
+++ b/Pokemon/BasePkmn.cs
@@ -14,6 +14,7 @@ using Terraria.ModLoader.Utilities;
 using TerramonMod.Items;
 using static TerramonMod.TerramonMod;
 using TerramonMod.Pokemon.Dusts;
+using TerramonMod.Pokemon.Gen1;
 
 namespace TerramonMod.Pokemon
 {
@@ -24,6 +25,7 @@ namespace TerramonMod.Pokemon
 		public virtual float commodity => 1f;
 		public virtual bool doesFly => false;
 
+		public bool isShimmer = false;
 		public bool isShiny = false;
 		public bool catchable = true;
 		public int catchAttempts = 0;
@@ -82,6 +84,7 @@ namespace TerramonMod.Pokemon
 			NPC.DeathSound = null;
 			NPC.netAlways = true;
 			NPC.friendly = true;
+			NPCID.Sets.ShimmerTownTransform[NPC.type] = true;
 			//NPC.noGravity = true;
 			//NPC.wet = true;
 			//NPC.scale = 2;
@@ -224,6 +227,11 @@ namespace TerramonMod.Pokemon
 				level = Main.rand.Next(1, 5);
 			}
 
+			NPCID.Sets.ShimmerTownTransform[NPC.type] = !isShimmer;
+
+			if (NPC.IsShimmerVariant)
+				isShimmer = true;
+
 			//info.Nickname = null;
 
 			base.AI();
@@ -330,7 +338,7 @@ namespace TerramonMod.Pokemon
 		{
 			// get the sprite path
 			string spritePath = Texture;
-			if (isShiny)
+			if (isShiny || isShimmer)
 			{
 				spritePath += "_Shiny";
 			}

--- a/Pokemon/BasePkmnPet.cs
+++ b/Pokemon/BasePkmnPet.cs
@@ -87,12 +87,12 @@ namespace TerramonMod.Pokemon
 
         public override bool PreDraw(ref Color lightColor)
 		{
-			Player player = Main.player[Projectile.owner];
+			var player = Main.player[Projectile.owner].GetModPlayer<TerramonPlayer>();
 
 			// get the sprite path
 			string spritePath = Texture;
 
-			if (player.GetModPlayer<TerramonPlayer>().usePokeIsShiny)
+			if (player.usePokeIsShiny || player.usePokeIsShimmer)
 			{
 				spritePath += "_Shiny";
 			}
@@ -127,11 +127,20 @@ namespace TerramonMod.Pokemon
 			//frameTimer = 0;
 
 			var tmonPlayer = Main.player[Projectile.owner].GetModPlayer<TerramonPlayer>();
-			if (tmonPlayer.pokeInUse != null && tmonPlayer.pokeInUse.data.IsEvolveReady())
-			{
-				if ((int)Main.rand.Next(0, 60) == 0)
-					Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, DustID.TreasureSparkle);
-			}
+			if (tmonPlayer.pokeInUse != null)
+            {
+				int dust = -1;
+
+				if (tmonPlayer.usePokeIsShiny && GetMoveSpeed() > 0.2f)
+					if ((int)Main.rand.Next(0, 25) == 0)
+						dust = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, DustID.GolfPaticle, newColor: tmonPlayer.pokeInUse.data.IsEvolveReady() ? Color.Yellow : Color.White, Scale: 1.5f);
+				else if (tmonPlayer.pokeInUse.data.IsEvolveReady())
+					if ((int)Main.rand.Next(0, 60) == 0)
+						dust = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, DustID.TreasureSparkle);
+
+				if (dust != -1)
+					Main.dust[dust].noGravity = true;
+            }
 
 			Projectile.frame = currentFrame;
 		}

--- a/Pokemon/PkmnData.cs
+++ b/Pokemon/PkmnData.cs
@@ -16,6 +16,7 @@ namespace TerramonMod.Pokemon
         public string pkmn = null;
         public string Nickname = null;
         public bool isShiny = false;
+        public bool isShimmer = false;
         public int level = 1;
 
         /*public void Evolve()
@@ -113,7 +114,7 @@ namespace TerramonMod.Pokemon
             string output = "";
             if (Nickname != null)
                 output = $"{Nickname}: ";
-            output += $"Level {level} {info.Name}. It is a {info.type1}";
+            output += $"Level {level} {(isShiny ? "Shiny " : null)}{info.Name}. It is a {info.type1}";
             if (info.type2 != null)
                 output += $"-{info.type2.Value}";
             output += " type.";

--- a/TerramonPlayer.cs
+++ b/TerramonPlayer.cs
@@ -24,6 +24,7 @@ namespace TerramonMod
 
 		public int usePokePet = -1;
 		public bool usePokeIsShiny = false;
+		public bool usePokeIsShimmer = false;
 
 		public int premierBonusCount = 0;
 
@@ -88,6 +89,7 @@ namespace TerramonMod
 			{
 				usePokePet = pokeInUse.data.GetInfo().petType;
 				usePokeIsShiny = pokeInUse.data.isShiny;
+				usePokeIsShimmer =  pokeInUse.data.isShimmer;
 			}
 			else
 				usePokePet = -1;
@@ -128,6 +130,7 @@ namespace TerramonMod
 			packet.Write((byte)Player.whoAmI);
 			packet.Write(usePokePet); // While we sync nonStopParty in SendClientChanges, we still need to send it here as well so newly joining players will receive the correct value.
 			packet.Write(usePokeIsShiny);
+			packet.Write(usePokeIsShimmer);
 			packet.Send(toWho, fromWho);
 		}
 
@@ -135,7 +138,9 @@ namespace TerramonMod
 		{
 			// Here we would sync something like an RPG stat whenever the player changes it.
 			TerramonPlayer clone = clientPlayer as TerramonPlayer;
-			if (clone.usePokePet != usePokePet || clone.usePokeIsShiny != usePokeIsShiny)
+			if (clone.usePokePet != usePokePet || 
+				clone.usePokeIsShiny != usePokeIsShiny || 
+				clone.usePokeIsShimmer != usePokeIsShimmer)
 			{
 				// Send a Mod Packet with the changes.
 				var packet = Mod.GetPacket();
@@ -143,6 +148,7 @@ namespace TerramonMod
 				packet.Write((byte)Player.whoAmI);
 				packet.Write(usePokePet);
 				packet.Write(usePokeIsShiny);
+				packet.Write(usePokeIsShimmer);
 				packet.Send();
 			}
 		}


### PR DESCRIPTION
- Add Rare Candies to NPC loot tables
- Add ChestGen class to handle adding/removing items from chests on world generation
- Add ChestID class to store chest spritesheet values
- Add custom worldgen pass to add Rare Candies and stones to chests
- Add Link Cable to Mechanic's trades
- Add shimmer mechanics to Pokemon
- Add shimmer mechanics to Water, Fire and Thunder stones
- Add shimmer mechanics to Poke Balls
- Fixed bug where Pokemon wouldn't retain their level and shiny status after breaking out of a Poke Ball
- Added sparkle effect to shiny Pokemon
- Poke Ball right-click message now tells you its shiny status
- Catch congratulation message now tells you its shiny status
- Change prices for Rare Candy, Link Cable, and evolution items