### PR TITLE
Clerk changes + finalisation

### DIFF
--- a/ChestGen.cs
+++ b/ChestGen.cs
@@ -21,7 +21,7 @@ namespace GenUtils
             for (int chestIndex = 0; chestIndex < Main.maxChests; chestIndex++)
             {
                 //if the drop chance for this chest is unsuccessful, skip this chest
-                if (WorldGen.genRand.Next(0, 10000) <= chance)
+                if (WorldGen.genRand.Next(0, 10000) < chance)
                     continue;
 
                 Chest chest = Main.chest[chestIndex];

--- a/Items/BasePkballItem.cs
+++ b/Items/BasePkballItem.cs
@@ -138,6 +138,7 @@ namespace TerramonMod.Items
 			}*/ //removed due to swapping balls whenever a new one is picked up
 			return false;
         }
+
 		public override bool CanStackInWorld(Item item2) => CanStack(item2);
 
         public override bool PreDrawInWorld(SpriteBatch spriteBatch, Color lightColor, Color alphaColor, ref float rotation, ref float scale, int whoAmI)

--- a/Items/ChestLoot.cs
+++ b/Items/ChestLoot.cs
@@ -28,8 +28,8 @@ namespace TerramonMod.Items
             ChestGen.AddChestLoot(ModContent.ItemType<WaterStone>(), ChestID.Water, chance: 8500);
             ChestGen.AddChestLoot(ModContent.ItemType<ThunderStone>(), ChestID.Dungeon, chance: 500);
             ChestGen.AddChestLoot(ModContent.ItemType<FireStone>(), ChestID.Shadow_Locked, chance: 1000);
-            ChestGen.AddChestLoot(ModContent.ItemType<LeafStone>(), ChestID.LivingTrees, chance: 4000);
-            ChestGen.AddChestLoot(ModContent.ItemType<MoonStone>(), ChestID.Gold, chance: 750);
+            ChestGen.AddChestLoot(ModContent.ItemType<LeafStone>(), ChestID.LivingTrees, chance: 1500);
+            ChestGen.AddChestLoot(ModContent.ItemType<MoonStone>(), ChestID.Gold, chance: 500);
 
         }
     }

--- a/Localization/en-US_Mods.TerramonMod.hjson
+++ b/Localization/en-US_Mods.TerramonMod.hjson
@@ -39,28 +39,23 @@ Items: {
 	}
 
 	TrainerCap: {
-		DisplayName: Trainer Cap
-		Tooltip: ""
-	}
-
-	TrainerLegs: {
-		DisplayName: Trainer Legs
+		DisplayName: Pokemon Trainer Cap
 		Tooltip: ""
 	}
 
 	TrainerTorso: {
-		DisplayName: Trainer Torso
+		DisplayName: Pokemon Trainer Jacket
+		Tooltip: ""
+	}
+
+	TrainerLegs: {
+		DisplayName: Pokemon Trainer Jeans
 		Tooltip: ""
 	}
 
 	MusicItemCenter: {
-		DisplayName: Pokemon Centre Music Box
+		DisplayName: Music Box (Pokemon Center)
 		Tooltip: ""
-	}
-
-	BasePkballItem: {
-		Tooltip: ""
-		DisplayName: Base Pkball Item
 	}
 
 	WaterStone: {
@@ -92,37 +87,25 @@ Items: {
 		DisplayName: Linking Cord
 		Tooltip: A cable that makes you feel a strange sense of connection. It’s loved by certain Pokemon.
 	}
-
-	ShimmerBallItem: {
-		DisplayName: Shimmer Ball Item
-		Tooltip: ""
-	}
-
-	PokeBombItem: {
-		DisplayName: Poke Bomb Item
-		Tooltip: ""
-	}
 }
 
 NPCs: {
 	PokemartClerk: {
-		DisplayName: Pokemart Clerk
+		DisplayName: PokeMart Clerk
 
 		TownNPCMood: {
-			Content: I am content.
-			NoHome: I hate not having a home.
-			FarFromHome: I am too far from home.
-			LoveSpace: I love having so much space.
-			DislikeCrowded: I dislike how crowded I am.
-			HateCrowded: I hate how crowded I am.
-			LoveBiome: I love {BiomeName}.
-			LikeBiome: I like {BiomeName}.
-			DislikeBiome: I dislike {BiomeName}.
-			LoveNPC: I love {NPCName}.
-			LikeNPC: I like {NPCName}.
-			DislikeNPC: I dislike {NPCName}.
-			HateNPC: I hate {NPCName}.
-			LikeNPC_Princess: I like {NPCName}.
+			Content: I rather enjoy my living space.
+			NoHome: I wish I had somewhere to live.
+			FarFromHome: I miss being back at my home.
+			LoveSpace: I love how much space there is for wild Pokemon to appear!
+			DislikeCrowded: Although there are plenty of people to talk to, it's a bit crowded.
+			HateCrowded: There are way too many people living here!
+			LikeBiome: There are so many Pokemon to see in {BiomeName}!
+			DislikeBiome: I dislike {BiomeName}. It's so creepy and everything is out to get you!
+			LikeNPC: I like {NPCName}. They've helped me out a ton.
+			LikeNPC_Princess: I like {NPCName}. Who doesn't?
+			DislikeNPC: I find {NPCName} a bit too loud.
+			HateNPC: I hate {NPCName}. He just doesn't respect Pokemon.
 			Princess_LovesNPC: I like {NPCName}.
 		}
 	}
@@ -283,8 +266,6 @@ Projectiles: {
 	PokeBallProjectile.DisplayName: Poke Ball
 	PremierBallProjectile.DisplayName: Premier Ball
 	UltraBallProjectile.DisplayName: Ultra Ball
-	BasePkballProjectile.DisplayName: Base Pkball Projectile
-	BasePkmnPet.DisplayName: Base Pkmn
 	AbraPet.DisplayName: Abra
 	AerodactylPet.DisplayName: Aerodactyl
 	AlakazamPet.DisplayName: Alakazam
@@ -432,7 +413,6 @@ Projectiles: {
 	ZubatPet.DisplayName: Zubat
 	NidoranFPet.DisplayName: Nidoran F
 	NidoranMPet.DisplayName: Nidoran M
-	ShimmerBallProjectile.DisplayName: Shimmer Ball Projectile
 	PokeBomb.DisplayName: Poke Bomb
 }
 

--- a/NPCs/PokemartClerk.cs
+++ b/NPCs/PokemartClerk.cs
@@ -28,7 +28,7 @@ namespace TerramonMod.NPCs
     public class PokemartClerk : ModNPC
     {
         private static int ShimmerHeadIndex;
-        private static Profiles.StackedNPCProfile NPCProfile;
+        private static StackedNPCProfile NPCProfile;
         public override void Load()
         {
             // Adds our Shimmer Head to the NPCHeadLoader.
@@ -45,7 +45,7 @@ namespace TerramonMod.NPCs
             NPCID.Sets.AttackType[Type] = 0;
             NPCID.Sets.AttackTime[Type] = 90; // The amount of time it takes for the NPC's attack animation to be over once it starts.
             NPCID.Sets.AttackAverageChance[Type] = 30;
-            NPCID.Sets.HatOffsetY[Type] = 3; // For when a party is active, the party hat spawns at a Y offset.
+            NPCID.Sets.HatOffsetY[Type] = 2; // For when a party is active, the party hat spawns at a Y offset.
             NPCID.Sets.ShimmerTownTransform[Type] = true;
 
             // Influences how the NPC looks in the Bestiary
@@ -59,21 +59,22 @@ namespace TerramonMod.NPCs
 
             NPCID.Sets.NPCBestiaryDrawOffset.Add(Type, drawModifiers);
 
-            // Set Example Person's biome and neighbor preferences with the NPCHappiness hook. You can add happiness text and remarks with localization (See an example in ExampleMod/Localization/en-US.lang).
-            // NOTE: The following code uses chaining - a style that works due to the fact that the SetXAffection methods return the same NPCHappiness instance they're called on.
             NPC.Happiness
-                //.SetBiomeAffection<Biome>
-                .SetBiomeAffection<ForestBiome>(AffectionLevel.Like) // Example Person prefers the forest.
-                .SetBiomeAffection<SnowBiome>(AffectionLevel.Dislike) // Example Person dislikes the snow.
-                .SetBiomeAffection<DesertBiome>(AffectionLevel.Love) // Example Person likes the desert.
-                .SetNPCAffection(NPCID.Dryad, AffectionLevel.Love) // Loves living near the dryad.
-                .SetNPCAffection(NPCID.Guide, AffectionLevel.Like) // Likes living near the guide.
-                .SetNPCAffection(NPCID.Merchant, AffectionLevel.Dislike) // Dislikes living near the merchant.
-                .SetNPCAffection(NPCID.Demolitionist, AffectionLevel.Hate) // Hates living near the demolitionist.
+                .SetBiomeAffection<OceanBiome>(AffectionLevel.Like)
+                .SetBiomeAffection<ForestBiome>(AffectionLevel.Like)
+                .SetBiomeAffection<CorruptionBiome>(AffectionLevel.Dislike)
+                .SetBiomeAffection<CrimsonBiome>(AffectionLevel.Dislike)
+                .SetNPCAffection(NPCID.Mechanic, AffectionLevel.Like)
+                .SetNPCAffection(NPCID.Merchant, AffectionLevel.Like)
+                .SetNPCAffection(NPCID.Princess, AffectionLevel.Like)
+                .SetNPCAffection(NPCID.Pirate, AffectionLevel.Dislike)
+                .SetNPCAffection(NPCID.ArmsDealer, AffectionLevel.Hate)
             ; // < Mind the semicolon!
 
+            //breeder - bestiarygirl, nurse    stylist, partygirl
+
             // This creates a "profile" for our NPC, which allows for different textures during a party and/or while the NPC is shimmered.
-            NPCProfile = new Profiles.StackedNPCProfile(
+            NPCProfile = new StackedNPCProfile(
                 new DefaultNPCProfile(Texture, NPCHeadLoader.GetHeadSlot(HeadTexture)),
                 new DefaultNPCProfile(Texture + "_Shimmer", ShimmerHeadIndex, Texture + "_Shimmer_Hatless")
             );
@@ -120,10 +121,16 @@ namespace TerramonMod.NPCs
         public override List<string> SetNPCNameList()
         {
             return new List<string>() {
-                "Ash",
-                "Somebody",
-                "Blocky",
-                "Colorless"
+                "Martin",
+                "Tom",
+                "Dave",
+                "Morshu",
+                "Terry",
+                "Steven",
+                "Xavier",
+                "Asher",
+                "Pikachu",
+                "Lance"
             };
         }
 
@@ -141,20 +148,54 @@ namespace TerramonMod.NPCs
             chat.Add("There are many different regions in the world. One day I hope to visit all of them!");
             //chat.Add("I conveniently sell Pokéballs for you to buy, but if you're short of cash you can always make your own using apricorns and iron!");
             chat.Add("A remake of Mobile Creatures has been announced! Though I'm not sure how I feel about the art style...");
-            chat.Add($"Ever since Pokémon started appearing in {Main.worldName}, I've dedicated my life to helping people care for them properly.");
+            chat.Add($"Ever since Pokémon started appearing in {Main.worldName}, I've dedicated my life to helping people learn more about them.");
             chat.Add("The Pokémon around here seem very peaceful. It's unusual to see creatures geting along so well.");
+
+            if (NPC.GivenName == "Pikachu")
+                chat.Add("Now, I know what you're thinking. \"That's such a creative name!\"");
+
+            //only add chat about Pokemon if it exists
+            if (player.pokeInUse != null)
+            {
+                chat.Add($"Is that your {player.pokeInUse.data.GetInfo().Name}? Hi, {player.pokeInUse.data.GetName()}!");
+
+                if (player.pokeInUse.data.Nickname == null)
+                    chat.Add("Did you know you can give your Pokemon a nickname? Type \"/nickname \" in the chat alongside the name of your choice.");
+                else
+                    chat.Add($"{player.pokeInUse.data.Nickname}? That's a lovely name! I can tell you care about your Pokemon very much.");
+
+                var pokemonType = player.pokeInUse.data.GetInfo().type1;
+                if (pokemonType == TerramonMod.PkmnType.grass)
+                    chat.Add($"Is that a grass type Pokemon? Those are my favourite!");
+                else if (pokemonType == TerramonMod.PkmnType.ice)
+                    chat.Add($"An Ice type Pokemon! I've always loved seeing those.");
+
+                if (player.usePokeIsShiny)
+                    chat.Add("Is that a shiny Pokemon? That's incredible! I wish I had one myself.");
+                else if (player.usePokeIsShimmer)
+                    chat.Add("Interesting... Your Pokemon has the same colors as a shiny Pokemon, but none of the... well- shine.");
+            }
+
             if (NPC.IsShimmerVariant)
                 chat.Add("Like my outfit? I look just like a real Pokemon Trainer!");
             else
                 chat.Add("Have you heard of Shimmer? Apparently it can give people their own shiny form!");
-            if (player.usePokeIsShiny)
-                chat.Add("Is that a shiny Pokemon? That's incredible! I wish I had one myself.");
-            else if (player.usePokeIsShimmer)
-                chat.Add("Interesting... Your Pokemon has the same colors as a shiny Pokemon, but none of the... well - shine.");
 
             var merchant = NPC.FindFirstNPC(NPCID.Merchant);
             if (merchant >= 0)
                 chat.Add(Language.GetTextValue($"{Main.npc[merchant].GivenName} may be a bit greedy, but he has taught me everything I know about commerce."));
+
+            var mechanic = NPC.FindFirstNPC(NPCID.Mechanic);
+            if (mechanic >= 0)
+                chat.Add(Language.GetTextValue($"{Main.npc[mechanic].GivenName} knows a lot about Poke Balls. Maybe one day I could start selling more of them!"));
+
+            var pirate = NPC.FindFirstNPC(NPCID.Pirate);
+            if (pirate >= 0)
+                chat.Add(Language.GetTextValue($"Have you tried speaking to {Main.npc[pirate].GivenName}? I can never understand what he is saying."));
+
+            var armsDealer = NPC.FindFirstNPC(NPCID.ArmsDealer);
+            if (armsDealer >= 0)
+                chat.Add(Language.GetTextValue($"Can you tell {Main.npc[armsDealer].GivenName} to stop shooting at the Pokemon??"));
 
             return chat; // chat is implicitly cast to a string.
         }

--- a/Pokemon/BasePkmn.cs
+++ b/Pokemon/BasePkmn.cs
@@ -91,6 +91,8 @@ namespace TerramonMod.Pokemon
 			//NPC.dontTakeDamage = true;
 		}
 
+		public override bool? CanBeCaughtBy(Item item, Player player) => false;
+
         public override float SpawnChance(NPCSpawnInfo spawnInfo)
         {
             float spawnChance = 0f;
@@ -347,7 +349,7 @@ namespace TerramonMod.Pokemon
 			Texture2D sprite = ModContent.Request<Texture2D>(spritePath).Value;
 
 			// draw the sprite
-			spriteBatch.Draw(sprite, new Vector2(NPC.Center.X - (NPC.frame.Width * 0.19f), NPC.Center.Y - (NPC.frame.Height * 0.39f)) - screenPos, NPC.frame, NPC.GetShimmerColor(Color.White), NPC.rotation, NPC.Size / 2, NPC.scale * 2, NPC.spriteDirection == 1 ? SpriteEffects.FlipHorizontally : SpriteEffects.None, 0f);
+			spriteBatch.Draw(sprite, new Vector2(NPC.Center.X - (NPC.frame.Width * 0.19f), NPC.Center.Y - (NPC.frame.Height * 0.39f)) - screenPos, NPC.frame, NPC.GetShimmerColor(drawColor), NPC.rotation, NPC.Size / 2, NPC.scale * 2, NPC.spriteDirection == 1 ? SpriteEffects.FlipHorizontally : SpriteEffects.None, 0f);
 			return false;
 		}
 

--- a/Tiles/MusicBoxCenter.cs
+++ b/Tiles/MusicBoxCenter.cs
@@ -1,4 +1,5 @@
 using Microsoft.Xna.Framework;
+using TerramonMod.Items.Pokeballs;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.GameContent.Creative;
@@ -67,6 +68,14 @@ namespace TerramonMod.Tiles
 			Item.rare = ItemRarityID.LightRed;
 			Item.value = 100000;
 			Item.accessory = true;
+		}
+
+		public override void AddRecipes()
+		{
+			CreateRecipe()
+				.AddIngredient(ItemID.MusicBox)
+				.AddTile(TileID.TinkerersWorkbench)
+				.Register();
 		}
 	}
 }

--- a/build.txt
+++ b/build.txt
@@ -1,4 +1,5 @@
-displayName = Terramon - Pokemon in Terraria!
+displayName = Terramon Beta
 author = Terramon Team
-version = 1.0
-homepage = https://discord.gg/U8skDEA
+version = 0.1
+homepage = https://terramon.carrd.co
+buildIgnore = Commands/Developer/*


### PR DESCRIPTION
- Added biome and NPC data to PokeMart Clerk
- Gave PokeMart Clerk more dialogue relating to biome/NPC/your Pokemon
- Change party hat offset for PokeMart Clerk
- Added names list for PokeMart NPC
- Pokemon NPCs now respond to lighting again (this got disabled when applying shimmer transparency)
- Pokemon can no longer get caught by a Bug Net (previously turned them into bunnies)
- Added localisation for the Pokemon Trainer set
- Reduce spawn chance for Leaf Stones and Moon Stones
- Added recipe for the Pokemon Center music box
- Change mod name, version and homepage in build.txt
- Added dev commands to the build ignore